### PR TITLE
Add Travis config and README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.03
+  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
+os:
+  - linux
+  - osx

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mwt - Preemptive threads and thread pools for Lwt
 
+[![Build Status](https://travis-ci.com/hcarty/mwt.svg?branch=master)](https://travis-ci.com/hcarty/mwt)
+
 `Mwt` allows a Lwt promise to hand off tasks to OCaml's preemptive threads.
 
 `Mwt` is similar to `Lwt_preemptive`, but with user-managed pools of stateful


### PR DESCRIPTION
The builds need to be started on https://travis-ci.com/ before the badge will properly show build status.